### PR TITLE
Added authorisation for product import call

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -32,12 +32,16 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
 
   const uploadFile = async (e: any) => {
       // Get the presigned URL
+      axios.defaults.headers['Authorization'] = `Basic ${localStorage.getItem('authorization_token')}`
       const response = await axios({
         method: 'GET',
         url,
         params: {
           name: encodeURIComponent(file.name)
-        }
+        },
+        headers: {
+          Authorization: `Basic ${localStorage.getItem('authorization_token')}`,
+        },
       })
       console.log('File to upload: ', file.name)
       console.log('Uploading to: ', response.data)
@@ -47,8 +51,7 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
       })
       console.log('Result: ', result)
       setFile('');
-    }
-  ;
+    };
 
   return (
     <div className={classes.content}>

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -2,7 +2,7 @@
 const API_PATHS = {
   product: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
   order: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
-  import: 'https://7ovvn6h9sj.execute-api.eu-west-1.amazonaws.com/dev',
+  import:'https://f9eal1tq2d.execute-api.eu-west-1.amazonaws.com/dev',
   bff: 'https://.execute-api.eu-west-1.amazonaws.com/dev'
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,9 +16,21 @@ axios.interceptors.response.use(
     if (error.response && error.response.status === 400) {
       alert(error.response.data?.data);
     }
+
+    if (error.response.status === 401) {
+      alert(error.response.data);
+    }	
+
+    if (error.response.status === 403) {
+      alert(error.response.data);
+    }
     return Promise.reject(error.response);
   }
 );
+const credentials = {login: 'lex', password: 'passwordD'}
+const encodedCreds = Buffer.from(`${credentials.login}:${credentials.password}`).toString('base64');
+
+localStorage.setItem('authorization_token', encodedCreds);
 
 ReactDOM.render(
   <React.StrictMode>


### PR DESCRIPTION
Take an authorization header from local storage +
Display alerts for the responses in 401 and 403 HTTP statuses +
At last moment I noticed that I had braked authorizer. The firs call to api gateway all time with fail status, and to check you need to do the additional call. That is becase the first axios OPTIONS call without token and aws answer with 403 error code, after repeat call manually the result is 200.
![Снимок](https://user-images.githubusercontent.com/43163508/100680202-17068380-3382-11eb-9046-efb8c6281445.PNG)
